### PR TITLE
This reproduces a bug in AVA (maybe?). Just run `$ npm t` and you'll …

### DIFF
--- a/test/bin.js
+++ b/test/bin.js
@@ -1,0 +1,11 @@
+import test from 'ava'
+
+test.todo('test bin later')
+
+try {
+  require('./bin') // requiring now for coverage until this is tested
+} catch (error) {
+  // ignore the inevitable error
+}
+
+

--- a/test/index.js
+++ b/test/index.js
@@ -2,12 +2,6 @@ import mock from 'mock-fs'
 import test from 'ava'
 import findNewRules from './index'
 
-try {
-  require('./bin') // requiring now for coverage until this is tested
-} catch (error) {
-  // ignore the inevitable error
-}
-
 test.before(() => {
   mock({
     './node_modules/eslint/lib/rules': {


### PR DESCRIPTION
…get:

```
(node) warning: possible EventEmitter memory leak detected. 11 test listeners added. Use emitter.setMaxListeners() to increase limit.
Trace
    at TestCollection.addListener (events.js:239:17)
    at Runner.run (/Users/kdodds/Developer/eslint-find-new-rules/node_modules/ava/lib/runner.js:127:13)
    at process.<anonymous> (/Users/kdodds/Developer/eslint-find-new-rules/node_modules/ava/index.js:90:10)
    at emitOne (events.js:77:13)
    at process.emit (events.js:169:7)
    at process.<anonymous> (/Users/kdodds/Developer/eslint-find-new-rules/node_modules/ava/lib/test-worker.js:124:10)
    at emitTwo (events.js:87:13)
    at process.emit (events.js:172:7)
    at handleMessage (internal/child_process.js:689:10)
    at Pipe.channel.onread (internal/child_process.js:440:11)
```
