### PR TITLE
fixed #9 use `ava` instead of `npm t` for `cover`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ before_script:
   - npm prune
 script:
   - npm run validate
-  - npm run check-coverage
 after_success:
   - 'curl -Lo travis_after_all.py https://git.io/travis_after_all'
   - python travis_after_all.py

--- a/package.json
+++ b/package.json
@@ -4,13 +4,13 @@
   "description": "Use this to save yourself some time when working on a webpack configuration.",
   "main": "index.js",
   "scripts": {
-    "cover": "nyc --reporter=lcov --reporter=text npm t",
+    "cover": "nyc --reporter=lcov --reporter=text ava",
     "test": "ava",
     "lint": "eslint .",
     "check-kentcdodds": "./bin.js eslint-config-kentcdodds",
     "update-contributors": "all-contributors generate",
     "commit": "git-cz",
-    "validate": "npm-run-all --parallel lint cover",
+    "validate": "npm-run-all --parallel lint cover --sequential check-coverage",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post",
     "check-coverage": "nyc check-coverage --statements 71 --branches 33 --functions 100 --lines 71",
     "report-coverage": "cat ./coverage/lcov.info | node_modules/.bin/codecov"


### PR DESCRIPTION
The `ERROR: No coverage files found.` issue gets resolved by passing the `--coverage` option to the `npm run cover`

<img width="909" alt="screen_shot_2016-03-17_at_11_10_18_am" src="https://cloud.githubusercontent.com/assets/949380/13856141/105ea410-ec31-11e5-850a-18daf620e5f2.png">
