### PR TITLE
chore(contributors): Fix contributor links and update all-contributors-cli

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -7,7 +7,7 @@
       "login": "kentcdodds",
       "name": "Kent C. Dodds",
       "avatar_url": "https://avatars3.githubusercontent.com/u/1500684?v=3",
-      "html_url": "https://twitter.com/kentcdodds",
+      "profile": "https://twitter.com/kentcdodds",
       "contributions": [
         "code", "doc", "test", "review"
       ]
@@ -16,7 +16,7 @@
       "login": "mgol",
       "name": "Michał Gołębiowski",
       "avatar_url": "https://avatars3.githubusercontent.com/u/1758366?v=3",
-      "html_url": "https://github.com/mgol",
+      "profile": "https://github.com/mgol",
       "contributions": [
         "code"
       ]
@@ -25,7 +25,7 @@
       "login": "sarbbottam",
       "name": "Sarbbottam Bandyopadhyay",
       "avatar_url": "https://avatars1.githubusercontent.com/u/949380?v=3",
-      "html_url": "https://twitter.com/sarbbottam",
+      "profile": "https://twitter.com/sarbbottam",
       "contributions": [
         "test", "review"
       ]
@@ -34,9 +34,18 @@
       "login": "ta2edchimp",
       "name": "Andreas Windt",
       "avatar_url": "https://avatars1.githubusercontent.com/u/262436?v=3",
-      "html_url": "https://twitter.com/ta2edchimp",
+      "profile": "https://twitter.com/ta2edchimp",
       "contributions": [
         "code", "doc", "test"
+      ]
+    },
+    {
+      "login": "jfmengels",
+      "name": "Jeroen Engels",
+      "avatar_url": "https://avatars.githubusercontent.com/u/3869412?v=3",
+      "profile": "https://github.com/jfmengels",
+      "contributions": [
+        "doc"
       ]
     }
   ]

--- a/README.md
+++ b/README.md
@@ -9,9 +9,7 @@ to identify built-in ESLint rules that you're not explicitly configuring.
 [![downloads](https://img.shields.io/npm/dm/eslint-find-new-rules.svg?style=flat-square)](http://npm-stat.com/charts.html?package=eslint-find-new-rules&from=2015-08-01)
 [![MIT License](https://img.shields.io/npm/l/eslint-find-new-rules.svg?style=flat-square)](http://opensource.org/licenses/MIT)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](http://makeapullrequest.com)
-<!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-[![All Contributors](https://img.shields.io/badge/all_contributors-4-orange.svg?style=flat-square)](#contributors)
-<!-- ALL-CONTRIBUTORS-BADGE:END -->
+[![All Contributors](https://img.shields.io/badge/all_contributors-5-orange.svg?style=flat-square)](#contributors)
 
 ## Installation
 
@@ -72,8 +70,8 @@ eslint-find-new-rules
 Thanks goes to these wonderful people ([emoji key](https://github.com/kentcdodds/all-contributors#emoji-key)):
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
-| [![Kent C. Dodds](https://avatars3.githubusercontent.com/u/1500684?v=3&s=100)<br /><sub>Kent C. Dodds</sub>]()<br />[💻](https://github.com/kentcdodds/eslint-find-new-rules/commits?author=kentcdodds) [📖](https://github.com/kentcdodds/eslint-find-new-rules/commits?author=kentcdodds) [⚠️](https://github.com/kentcdodds/eslint-find-new-rules/commits?author=kentcdodds) 👀 | [![Michał Gołębiowski](https://avatars3.githubusercontent.com/u/1758366?v=3&s=100)<br /><sub>Michał Gołębiowski</sub>]()<br />[💻](https://github.com/kentcdodds/eslint-find-new-rules/commits?author=mgol) | [![Sarbbottam Bandyopadhyay](https://avatars1.githubusercontent.com/u/949380?v=3&s=100)<br /><sub>Sarbbottam Bandyopadhyay</sub>]()<br />[⚠️](https://github.com/kentcdodds/eslint-find-new-rules/commits?author=sarbbottam) 👀 | [![Andreas Windt](https://avatars1.githubusercontent.com/u/262436?v=3&s=100)<br /><sub>Andreas Windt</sub>]()<br />[💻](https://github.com/kentcdodds/eslint-find-new-rules/commits?author=ta2edchimp) [📖](https://github.com/kentcdodds/eslint-find-new-rules/commits?author=ta2edchimp) [⚠️](https://github.com/kentcdodds/eslint-find-new-rules/commits?author=ta2edchimp) |
-| :---: | :---: | :---: | :---: |
+| [![Kent C. Dodds](https://avatars3.githubusercontent.com/u/1500684?v=3&s=100)<br /><sub>Kent C. Dodds</sub>](https://twitter.com/kentcdodds)<br />[💻](https://github.com/kentcdodds/eslint-find-new-rules/commits?author=kentcdodds) [📖](https://github.com/kentcdodds/eslint-find-new-rules/commits?author=kentcdodds) [⚠️](https://github.com/kentcdodds/eslint-find-new-rules/commits?author=kentcdodds) 👀 | [![Michał Gołębiowski](https://avatars3.githubusercontent.com/u/1758366?v=3&s=100)<br /><sub>Michał Gołębiowski</sub>](https://github.com/mgol)<br />[💻](https://github.com/kentcdodds/eslint-find-new-rules/commits?author=mgol) | [![Sarbbottam Bandyopadhyay](https://avatars1.githubusercontent.com/u/949380?v=3&s=100)<br /><sub>Sarbbottam Bandyopadhyay</sub>](https://twitter.com/sarbbottam)<br />[⚠️](https://github.com/kentcdodds/eslint-find-new-rules/commits?author=sarbbottam) 👀 | [![Andreas Windt](https://avatars1.githubusercontent.com/u/262436?v=3&s=100)<br /><sub>Andreas Windt</sub>](https://twitter.com/ta2edchimp)<br />[💻](https://github.com/kentcdodds/eslint-find-new-rules/commits?author=ta2edchimp) [📖](https://github.com/kentcdodds/eslint-find-new-rules/commits?author=ta2edchimp) [⚠️](https://github.com/kentcdodds/eslint-find-new-rules/commits?author=ta2edchimp) | [![Jeroen Engels](https://avatars.githubusercontent.com/u/3869412?v=3&s=100)<br /><sub>Jeroen Engels</sub>](https://github.com/jfmengels)<br />[📖](https://github.com/kentcdodds/eslint-find-new-rules/commits?author=jfmengels) |
+| :---: | :---: | :---: | :---: | :---: |
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors](https://github.com/kentcdodds/all-contributors) specification.

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "path-is-absolute": "1.0.0"
   },
   "devDependencies": {
-    "all-contributors-cli": "2.0.0-beta3",
+    "all-contributors-cli": "2.0.0-beta6",
     "ava": "0.13.0",
     "codecov": "1.0.1",
     "commitizen": "2.7.2",


### PR DESCRIPTION
The avatars didn't have a link anymore, so I fixed that. Also, the `all-contributors` badge is on the same line as the other badges (a problem, now _finally_ resolved in `all-contributors-cli`).
