### PR TITLE
Use opt-cli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ node_modules/
 coverage/
 *.log
 dist/
+.opt-in
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,3 +19,23 @@
 12. Get merged
 13. Celebrate 🎉
 
+## Committing and Pushing changes
+
+As stated earlier, please follow [this convention](https://github.com/stevemao/conventional-changelog-angular/blob/master/convention.md) for your commit messages.
+
+Once you are ready to commit the changes, please use the below commands
+
+1. `git add <files to be comitted>`
+2. `$ npm run commit`
+
+... and follow the instruction of the interactive prompt.
+
+### Opt into run tests while committing
+
+`npm run commit` will not execute any `tests`, prior `commit`ing, however you can **opt into it**.
+
+In order to execute `tests` automatically before `commit`, create a file `.opt-in` in the root of the project with `pre-commit` as the content.
+
+Excute the following command in the root of the project to create the above stated file.
+
+`$ echo pre-commit > .opt-in`

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "ghooks": "1.0.3",
     "npm-run-all": "1.5.3",
     "nyc": "6.1.1",
+    "opt-cli": "^1.1.1",
     "proxyquire": "1.7.4",
     "semantic-release": "4.3.5",
     "validate-commit-msg": "2.4.0"
@@ -63,10 +64,10 @@
   "config": {
     "ghooks": {
       "commit-msg": "validate-commit-msg",
-      "pre-commit": "npm run validate"
+      "pre-commit": "opt --in pre-commit --exec \"npm run validate\""
     },
     "commitizen": {
-      "path": "node_modules/cz-conventional-changelog"
+      "path": "./node_modules/cz-conventional-changelog"
     }
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -61,10 +61,12 @@
     ]
   },
   "config": {
-    "commig-msg": "validate-commit-msg",
-    "pre-commit": "npm run validate",
+    "ghooks": {
+      "commit-msg": "validate-commit-msg",
+      "pre-commit": "npm run validate"
+    },
     "commitizen": {
-      "path": "./node_modules/cz-conventional-changelog"
+      "path": "node_modules/cz-conventional-changelog"
     }
   },
   "repository": {


### PR DESCRIPTION
Fixed `ghooks` in the [first commit](https://github.com/kentcdodds/eslint-find-new-rules/commit/823e565f9a14190ab613518cea1c0f61feb5cb10).
I am bit confused about the `opt-cli`, please refer the [second commit](https://github.com/kentcdodds/eslint-find-new-rules/commit/a8d3296f078f8fdc9e1c68612cf8a345c1084eba), I have followed the instructions provided at [opt-cli README](https://github.com/ta2edchimp/opt-cli/blob/master/README.md), however could not opt in to `precommit ghooks` even after creating a `.opt-in` file with `precommit`

```
吽 cat .opt-in
precommit
```

Any pointer would be helpful.
