### PR TITLE
docs(deprecation): deprecated in favor of eslint-find-rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # eslint-find-new-rules
 
+## Deprecation
+**This module is deprecated in favor of [eslint-find-rules](https://www.npmjs.com/package/eslint-find-rules/)**
+
+---
+
 Use this for your own [ESLint](http://eslint.org/) [shareable configuration](http://eslint.org/docs/developer-guide/shareable-configs)
 to identify built-in ESLint rules that you're not explicitly configuring.
 


### PR DESCRIPTION
added deprecation label as suggested.

> make a PR to this repo to add a reference to that project and label it as deprecated.
